### PR TITLE
Buttons show scales

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,7 +68,7 @@
         <option>mixolydian</option>
         <option>aeolien</option>
         <option>locrian</option>
-        <option>minor Pentatonic</option>
+        <option>minPentatonic</option>
       </select>
     </div>
 

--- a/scripts/fretboard.js
+++ b/scripts/fretboard.js
@@ -27,27 +27,23 @@ function String(name, low, high) {
 }
 
 function Fret(x, y, note, string) {
-  // var noteOnColor = color(93,81,214);
-  // var noteOffColor = color(30,28,52);
-
+  this.x = x;
+  this.y = y;
   this.note = note;
   this.string = string;
   this.active = false;
-  this.x = x;
-  this.y = y;
-  // this.col = color(30,28,52);
   this.display = function() {
-    // if (this.active) {
-    //   this.col = noteOnColor;
-    // } else {
-    //   this.col = noteOffColor;
-    // }
-    // fill(this.col);
-    ellipse(this.x, this.y, 7, 7);
+    var noteOnColor = color(93,81,214);
+    var noteOffColor = color(30,28,52);
+    if (this.active) {
+      this.col = noteOnColor;
+    } else {
+      this.col = noteOffColor;
+    }
+    fill(this.col);
+    ellipse(this.x, this.y, 9, 9);
   };
 }
-
-
 
 // 3. GENERATE DATA USING CONSTRUCTORS -----------------
 
@@ -78,26 +74,19 @@ var strings = [
   new String("E", 0, 24)
 ];
 
-// calculate the x and y position of the fret
-// define a distance from string to string
-// define a distance from fret to fret
-
-// 1. Draw the frets in the right place on the screen
-// 2. When select options are submitted, highlight the correct frets
-
 // Create fret objects and push them into frets array
 for (var i = 0; i < strings.length; i++) {
   var currentString = strings[i];
-  var stringDistance = (i * 20) + 20;
+  var stringDistance = (i * 20) + 100;
   for (var n = currentString.low; n <= currentString.high; n++) {
-    var noteDistance = ((n * 20) + 20) - (currentString.low * 20);
+    var noteDistance = ((n * 20) + 100) - (currentString.low * 20);
     var note = notes[n];
     frets.push(new Fret(noteDistance, stringDistance, note, currentString));
     // n = 0;
   }
 }
 
-// 4.DEFINE FUNCTIONS -----------------
+// 4. DEFINE FUNCTIONS -----------------
 
 // Calculates a scale by key and mode and activates it on the frets
 function setScale(key, mode) {
@@ -128,27 +117,6 @@ function activateFrets(foundScale) {
       }
     }
   }
-}
-
-// Loop through frets on each string to check for active status.
-// If the fret is active, show a "O", otherwise show a "-".
-function updateDisplay(mode) {
-  var fretboard = "";
-  for (var i = 0; i < strings.length; i++) {
-    for (var f = 0; f < frets.length; f++) {
-      if (frets[f].string == strings[i]) {
-        if (frets[f].active) {
-          fretboard += "O ";
-        } else {
-          fretboard += "- ";
-        }
-      }
-    }
-    fretboard += "\n";
-  }
-  // console.clear();
-  console.log("scale: " + currentKeyName + " " + scaleValueField.value + "   scale pattern: " + currentMode.pattern);
-  console.log(fretboard);
 }
 
 // Algorithm to find scale within a set of notes

--- a/scripts/fretboard.js
+++ b/scripts/fretboard.js
@@ -33,10 +33,22 @@ function Fret(x, y, note, string) {
   this.string = string;
   this.active = false;
   this.display = function() {
-    var noteOnColor = color(93,81,214);
+    var firstOctaveOnColor = color(74,32,193);
+    var secondOctaveOnColor = color(50,173,212);
+    var thirdOctaveOnColor = color(126,214,72);
+    var fourthOctaveOnColor = color(237,172,85);
+    var fifthOctaveOnColor = color(251,86,20);
     var noteOffColor = color(30,28,52);
-    if (this.active) {
-      this.col = noteOnColor;
+    if (this.active && note.id <= 12) {
+      this.col = firstOctaveOnColor;
+    } else if (this.active && note.id > 12 && note.id <= 24) {
+      this.col = secondOctaveOnColor;
+    } else if (this.active && note.id > 24 && note.id <= 36) {
+      this.col = thirdOctaveOnColor;
+    } else if (this.active && note.id > 36 && note.id <= 47) {
+      this.col = fourthOctaveOnColor;
+    } else if (this.active && note.id == 48) {
+      this.col = fifthOctaveOnColor;
     } else {
       this.col = noteOffColor;
     }
@@ -107,11 +119,7 @@ function activateFrets(foundScale) {
   for (var i = 0; i < foundScale.length; i++) {
     for (var f = 0; f < frets.length; f++) {
       if (frets[f].note == foundScale[i]) {
-        if (frets[f].active = true) {
-          frets[f].col = color(93,81,214);
-        } else if (frets[f].active = false){
-          frets[f].col = color(30,28,52);
-        }
+        frets[f].active = true;
       }
     }
   }

--- a/scripts/fretboard.js
+++ b/scripts/fretboard.js
@@ -27,20 +27,22 @@ function String(name, low, high) {
 }
 
 function Fret(x, y, note, string) {
+  // var noteOnColor = color(93,81,214);
+  // var noteOffColor = color(30,28,52);
+
   this.note = note;
   this.string = string;
   this.active = false;
   this.x = x;
   this.y = y;
+  // this.col = color(30,28,52);
   this.display = function() {
     // if (this.active) {
     //   this.col = noteOnColor;
-    // } else if (this.playColor) {
-    //   this.col = notePlayColor;
     // } else {
     //   this.col = noteOffColor;
     // }
-    fill(color(93,81,214));
+    // fill(this.col);
     ellipse(this.x, this.y, 7, 7);
   };
 }
@@ -118,7 +120,11 @@ function activateFrets(foundScale) {
   for (var i = 0; i < foundScale.length; i++) {
     for (var f = 0; f < frets.length; f++) {
       if (frets[f].note == foundScale[i]) {
-        frets[f].active = true;
+        if (frets[f].active = true) {
+          frets[f].col = color(93,81,214);
+        } else if (frets[f].active = false){
+          frets[f].col = color(30,28,52);
+        }
       }
     }
   }
@@ -140,7 +146,7 @@ function updateDisplay(mode) {
     }
     fretboard += "\n";
   }
-  console.clear();
+  // console.clear();
   console.log("scale: " + currentKeyName + " " + scaleValueField.value + "   scale pattern: " + currentMode.pattern);
   console.log(fretboard);
 }

--- a/scripts/fretboard.js
+++ b/scripts/fretboard.js
@@ -159,55 +159,37 @@ var scaleValueField = document.getElementById("scale-value");
 var showButton = document.getElementById("show-scale");
 var clearButton = document.getElementById("clear-scale");
 
+function processElement() {
+    // Grab the key value from the key select fields
+    currentKey = parseInt(keyValueField.selectedIndex);
+
+    // Grab the name of the key from the text content of the option element
+    currentKeyName = keyValueField.options[keyValueField.selectedIndex].textContent;
+
+    // Grab the current mode using the value from the mode select field
+    currentMode = modes[scaleValueField.value];
+
+    // Calculate and set the scale and display it in the console
+    setScale(currentKey, currentMode.pattern);
+}
+// 5. SET UP DOM EVENT LISTENERS AND WAIT FOR USER ACTION -----------------
+
 // When the show button is clicked, do the following...
 keyValueField.addEventListener("change", function() {
-
-  // Grab the key value from the key select fields
-  currentKey = parseInt(keyValueField.selectedIndex);
-
-  // Grab the name of the key from the text content of the option element
-  currentKeyName = keyValueField.options[keyValueField.selectedIndex].textContent;
-
-  // Grab the current mode using the value from the mode select field
-  currentMode = modes[scaleValueField.value];
-
-  // Calculate and set the scale and display it in the console
-  setScale(currentKey, currentMode.pattern);
+  processElement();
 });
 
 scaleValueField.addEventListener("change", function() {
-
-  // Grab the key value from the key select fields
-  currentKey = parseInt(keyValueField.selectedIndex);
-
-  // Grab the name of the key from the text content of the option element
-  currentKeyName = keyValueField.options[keyValueField.selectedIndex].textContent;
-
-  // Grab the current mode using the value from the mode select field
-  currentMode = modes[scaleValueField.value];
-
-  // Calculate and set the scale and display it in the console
-  setScale(currentKey, currentMode.pattern);
+  processElement();
 });
 
 showButton.addEventListener("click", function() {
-
-  // Grab the key value from the key select fields
-  currentKey = parseInt(keyValueField.selectedIndex);
-
-  // Grab the name of the key from the text content of the option element
-  currentKeyName = keyValueField.options[keyValueField.selectedIndex].textContent;
-
-  // Grab the current mode using the value from the mode select field
-  currentMode = modes[scaleValueField.value];
-
-  // Calculate and set the scale and display it in the console
-  setScale(currentKey, currentMode.pattern);
+  processElement();
 });
 
 // Clear fretboard and updateDisplay
 clearButton.addEventListener("click", function() {
-  clearFretSelection();
+  processElement();
 });
 
 // Required P5 function runs once to initialize setup

--- a/scripts/fretboard.js
+++ b/scripts/fretboard.js
@@ -160,6 +160,36 @@ var showButton = document.getElementById("show-scale");
 var clearButton = document.getElementById("clear-scale");
 
 // When the show button is clicked, do the following...
+keyValueField.addEventListener("change", function() {
+
+  // Grab the key value from the key select fields
+  currentKey = parseInt(keyValueField.selectedIndex);
+
+  // Grab the name of the key from the text content of the option element
+  currentKeyName = keyValueField.options[keyValueField.selectedIndex].textContent;
+
+  // Grab the current mode using the value from the mode select field
+  currentMode = modes[scaleValueField.value];
+
+  // Calculate and set the scale and display it in the console
+  setScale(currentKey, currentMode.pattern);
+});
+
+scaleValueField.addEventListener("change", function() {
+
+  // Grab the key value from the key select fields
+  currentKey = parseInt(keyValueField.selectedIndex);
+
+  // Grab the name of the key from the text content of the option element
+  currentKeyName = keyValueField.options[keyValueField.selectedIndex].textContent;
+
+  // Grab the current mode using the value from the mode select field
+  currentMode = modes[scaleValueField.value];
+
+  // Calculate and set the scale and display it in the console
+  setScale(currentKey, currentMode.pattern);
+});
+
 showButton.addEventListener("click", function() {
 
   // Grab the key value from the key select fields
@@ -173,13 +203,11 @@ showButton.addEventListener("click", function() {
 
   // Calculate and set the scale and display it in the console
   setScale(currentKey, currentMode.pattern);
-  updateDisplay();
 });
 
 // Clear fretboard and updateDisplay
 clearButton.addEventListener("click", function() {
   clearFretSelection();
-  updateDisplay();
 });
 
 // Required P5 function runs once to initialize setup

--- a/scripts/fretboard.js
+++ b/scripts/fretboard.js
@@ -82,7 +82,6 @@ for (var i = 0; i < strings.length; i++) {
     var noteDistance = ((n * 20) + 100) - (currentString.low * 20);
     var note = notes[n];
     frets.push(new Fret(noteDistance, stringDistance, note, currentString));
-    // n = 0;
   }
 }
 
@@ -92,7 +91,6 @@ for (var i = 0; i < strings.length; i++) {
 function setScale(key, mode) {
   var foundScale = getScale(key, mode);
   activateFrets(foundScale);
-
 }
 
 // Deactivates all frets to make blank slate
@@ -136,6 +134,7 @@ function getScale(key, scale) {
     modeIndex++;
   }
 
+  // Remove first note from foundScale in order to avoid doubling
   foundScale.splice(0,1);
   scale.reverse();
   noteInKey = key;
@@ -147,12 +146,12 @@ function getScale(key, scale) {
     noteInKey -= scale[modeIndex];
     modeIndex++;
   }
-
+  // Reset scale
   scale.reverse();
   return foundScale;
 }
 
-// 5.SET UP DOM EVENT LISTENERS AND WAIT FOR USER ACTION -----------------
+// 5. SET UP DOM EVENT LISTENERS AND WAIT FOR USER ACTION -----------------
 
 // Grab the select fields and buttons from the HTML document
 var keyValueField = document.getElementById("key-value");
@@ -183,23 +182,15 @@ clearButton.addEventListener("click", function() {
   updateDisplay();
 });
 
+// Required P5 function runs once to initialize setup
 function setup() {
   createCanvas(700, 500);
 }
-//
-// function play(){
-// }
-//
-// function mousePressed() {
-//   // for (var i = 0; i < frets.length; i++) {
-//   //   frets[i].clicked();
-//   // }
-// }
-//
+
+// Required P5 function loops forever
 function draw() {
   background(0);
   for (var i = 0; i < frets.length; i++) {
-    // turn frets[i].display(); back on to display
     frets[i].display();
   }
 }

--- a/scripts/fretboard.js
+++ b/scripts/fretboard.js
@@ -26,11 +26,26 @@ function String(name, low, high) {
   this.high = high;
 }
 
-function Fret(note, string) {
+function Fret(x, y, note, string) {
   this.note = note;
   this.string = string;
   this.active = false;
+  this.x = x;
+  this.y = y;
+  this.display = function() {
+    // if (this.active) {
+    //   this.col = noteOnColor;
+    // } else if (this.playColor) {
+    //   this.col = notePlayColor;
+    // } else {
+    //   this.col = noteOffColor;
+    // }
+    fill(color(93,81,214));
+    ellipse(this.x, this.y, 7, 7);
+  };
 }
+
+
 
 // 3. GENERATE DATA USING CONSTRUCTORS -----------------
 
@@ -61,12 +76,22 @@ var strings = [
   new String("E", 0, 24)
 ];
 
+// calculate the x and y position of the fret
+// define a distance from string to string
+// define a distance from fret to fret
+
+// 1. Draw the frets in the right place on the screen
+// 2. When select options are submitted, highlight the correct frets
+
 // Create fret objects and push them into frets array
 for (var i = 0; i < strings.length; i++) {
   var currentString = strings[i];
+  var stringDistance = (i * 20) + 20;
   for (var n = currentString.low; n <= currentString.high; n++) {
+    var noteDistance = ((n * 20) + 20) - (currentString.low * 20);
     var note = notes[n];
-    frets.push(new Fret(note, currentString));
+    frets.push(new Fret(noteDistance, stringDistance, note, currentString));
+    // n = 0;
   }
 }
 
@@ -184,9 +209,9 @@ clearButton.addEventListener("click", function() {
   updateDisplay();
 });
 
-// function setup() {
-//   // createCanvas(700, 500);
-// }
+function setup() {
+  createCanvas(700, 500);
+}
 //
 // function play(){
 // }
@@ -197,10 +222,10 @@ clearButton.addEventListener("click", function() {
 //   // }
 // }
 //
-// function draw() {
-//   // background(0);
-//   // for (var i = 0; i < frets.length; i++) {
-//   // turn frets[i].display(); back on to display
-//   // frets[i].display();
-//   // }
-// }
+function draw() {
+  background(0);
+  for (var i = 0; i < frets.length; i++) {
+    // turn frets[i].display(); back on to display
+    frets[i].display();
+  }
+}

--- a/scripts/fretboard.js
+++ b/scripts/fretboard.js
@@ -151,6 +151,20 @@ function getScale(key, scale) {
   return foundScale;
 }
 
+function processElement() {
+  // Grab the key value from the key select fields
+  currentKey = parseInt(keyValueField.selectedIndex);
+
+  // Grab the name of the key from the text content of the option element
+  currentKeyName = keyValueField.options[keyValueField.selectedIndex].textContent;
+
+  // Grab the current mode using the value from the mode select field
+  currentMode = modes[scaleValueField.value];
+
+  // Calculate and set the scale and display it in the console
+  setScale(currentKey, currentMode.pattern);
+}
+
 // 5. SET UP DOM EVENT LISTENERS AND WAIT FOR USER ACTION -----------------
 
 // Grab the select fields and buttons from the HTML document
@@ -158,21 +172,6 @@ var keyValueField = document.getElementById("key-value");
 var scaleValueField = document.getElementById("scale-value");
 var showButton = document.getElementById("show-scale");
 var clearButton = document.getElementById("clear-scale");
-
-function processElement() {
-    // Grab the key value from the key select fields
-    currentKey = parseInt(keyValueField.selectedIndex);
-
-    // Grab the name of the key from the text content of the option element
-    currentKeyName = keyValueField.options[keyValueField.selectedIndex].textContent;
-
-    // Grab the current mode using the value from the mode select field
-    currentMode = modes[scaleValueField.value];
-
-    // Calculate and set the scale and display it in the console
-    setScale(currentKey, currentMode.pattern);
-}
-// 5. SET UP DOM EVENT LISTENERS AND WAIT FOR USER ACTION -----------------
 
 // When the show button is clicked, do the following...
 keyValueField.addEventListener("change", function() {

--- a/scripts/fretboard.js
+++ b/scripts/fretboard.js
@@ -151,7 +151,7 @@ function getScale(key, scale) {
   return foundScale;
 }
 
-function processElement() {
+function processEventListenerElement() {
   // Grab the key value from the key select fields
   currentKey = parseInt(keyValueField.selectedIndex);
 
@@ -175,20 +175,20 @@ var clearButton = document.getElementById("clear-scale");
 
 // When the show button is clicked, do the following...
 keyValueField.addEventListener("change", function() {
-  processElement();
+  processEventListenerElement();
 });
 
 scaleValueField.addEventListener("change", function() {
-  processElement();
+  processEventListenerElement();
 });
 
 showButton.addEventListener("click", function() {
-  processElement();
+  processEventListenerElement();
 });
 
 // Clear fretboard and updateDisplay
 clearButton.addEventListener("click", function() {
-  processElement();
+  clearFretSelection()
 });
 
 // Required P5 function runs once to initialize setup

--- a/scripts/note.js
+++ b/scripts/note.js
@@ -1,93 +1,93 @@
-function Fret(x, y, number) {
-  var noteOnColor = color(93,81,214);
-  var noteOffColor = color(30,28,52);
-  var notePlayColor = color(207,221,50);
-
-  this.x = x;
-  this.y = y;
-  this.active = false;
-  this.playColor = false;
-  this.col = noteOnColor;
-  this.fretArrayNumber = number + 1;
-  this.audioNote = document.getElementById("_1");
-
-  this.display = function() {
-    if (this.active) {
-      this.col = noteOnColor;
-    } else if (this.playColor) {
-      this.col = notePlayColor;
-    } else {
-      this.col = noteOffColor;
-    }
-    fill(this.col);
-    ellipse(this.x, this.y, 7, 7);
-  };
-
-  this.clicked = function() {
-    var d = dist(mouseX, mouseY, this.x, this.y);
-    var note = this.fretArrayNumber;
-    if (d < 5 ) {
-      var fretNum = this.fretArrayNumber - 1;
-      var audio = frets[fretNum].audioNote;
-
-      if (this.active === true){
-        this.active = false;
-        this.playColor = true;
-        setTimeout(function() {
-          frets[fretNum].active = true;
-        }, 2700);
-      } else {
-        this.playColor = true;
-        setTimeout(function() {
-          frets[fretNum].playColor = false;
-        }, 2700);
-      }
-      // High E string note mapping
-      for (i = 1; i <= 25; i++) {
-        if (note === i || note === i + 150 || note === i + 300) {
-          this.fretArrayNumber = i + 24;
-          console.log(this.fretArrayNumber);
-        }
-      }
-      // B string note mapping
-      for (i = 26; i <= 50; i++) {
-        if (note === i || note === i + 150 || note === i + 300) {
-          this.fretArrayNumber = i - 6;
-          console.log(this.fretArrayNumber);
-        }
-      }
-      // G string note mapping
-      for (i = 51; i <= 75; i++) {
-        if (note === i || note === i + 150 || note === i + 300) {
-          this.fretArrayNumber = i - 35;
-          console.log(this.fretArrayNumber);
-        }
-      }
-      // D string note mapping
-      for (i = 76; i <= 100; i++) {
-        if (note === i || note === i + 150 || note === i + 300) {
-          this.fretArrayNumber = i - 65;
-          console.log(this.fretArrayNumber);
-        }
-      }
-      // A string note mapping
-      for (i = 101; i <= 125; i++) {
-        if (note === i || note === i + 150 || note === i + 300) {
-          this.fretArrayNumber = i - 95;
-          console.log(this.fretArrayNumber);
-        }
-      }
-      // Low E string note mapping
-      for (i = 126; i <= 150; i++) {
-        if (note === i || note === i + 150 || note === i + 300) {
-          this.fretArrayNumber = i - 125;
-          console.log(this.fretArrayNumber);
-          console.log(frets[i]);
-        }
-      }
-      this.audioNote.src = "audio/" + this.fretArrayNumber + ".mp3";
-      audio.play();
-      this.fretArrayNumber = number + 1;
-    }
-  };
-}
+// function Fret(x, y, number) {
+//   var noteOnColor = color(93,81,214);
+//   var noteOffColor = color(30,28,52);
+//   var notePlayColor = color(207,221,50);
+//
+//   this.x = x;
+//   this.y = y;
+//   this.active = false;
+//   this.playColor = false;
+//   this.col = noteOnColor;
+//   this.fretArrayNumber = number + 1;
+//   this.audioNote = document.getElementById("_1");
+//
+//   this.display = function() {
+//     if (this.active) {
+//       this.col = noteOnColor;
+//     } else if (this.playColor) {
+//       this.col = notePlayColor;
+//     } else {
+//       this.col = noteOffColor;
+//     }
+//     fill(this.col);
+//     ellipse(this.x, this.y, 7, 7);
+//   };
+//
+//   this.clicked = function() {
+//     var d = dist(mouseX, mouseY, this.x, this.y);
+//     var note = this.fretArrayNumber;
+//     if (d < 5 ) {
+//       var fretNum = this.fretArrayNumber - 1;
+//       var audio = frets[fretNum].audioNote;
+//
+//       if (this.active === true){
+//         this.active = false;
+//         this.playColor = true;
+//         setTimeout(function() {
+//           frets[fretNum].active = true;
+//         }, 2700);
+//       } else {
+//         this.playColor = true;
+//         setTimeout(function() {
+//           frets[fretNum].playColor = false;
+//         }, 2700);
+//       }
+//       // High E string note mapping
+//       for (i = 1; i <= 25; i++) {
+//         if (note === i || note === i + 150 || note === i + 300) {
+//           this.fretArrayNumber = i + 24;
+//           console.log(this.fretArrayNumber);
+//         }
+//       }
+//       // B string note mapping
+//       for (i = 26; i <= 50; i++) {
+//         if (note === i || note === i + 150 || note === i + 300) {
+//           this.fretArrayNumber = i - 6;
+//           console.log(this.fretArrayNumber);
+//         }
+//       }
+//       // G string note mapping
+//       for (i = 51; i <= 75; i++) {
+//         if (note === i || note === i + 150 || note === i + 300) {
+//           this.fretArrayNumber = i - 35;
+//           console.log(this.fretArrayNumber);
+//         }
+//       }
+//       // D string note mapping
+//       for (i = 76; i <= 100; i++) {
+//         if (note === i || note === i + 150 || note === i + 300) {
+//           this.fretArrayNumber = i - 65;
+//           console.log(this.fretArrayNumber);
+//         }
+//       }
+//       // A string note mapping
+//       for (i = 101; i <= 125; i++) {
+//         if (note === i || note === i + 150 || note === i + 300) {
+//           this.fretArrayNumber = i - 95;
+//           console.log(this.fretArrayNumber);
+//         }
+//       }
+//       // Low E string note mapping
+//       for (i = 126; i <= 150; i++) {
+//         if (note === i || note === i + 150 || note === i + 300) {
+//           this.fretArrayNumber = i - 125;
+//           console.log(this.fretArrayNumber);
+//           console.log(frets[i]);
+//         }
+//       }
+//       this.audioNote.src = "audio/" + this.fretArrayNumber + ".mp3";
+//       audio.play();
+//       this.fretArrayNumber = number + 1;
+//     }
+//   };
+// }


### PR DESCRIPTION
Hi Kevin,

Hope all is well!
So, I have a refined version to share.

I was able to get p5 to display the chosen scale, and I was able to hook up the select elements so that when a scale or key is chosen, the scale is refreshed on the screen automatically without having to click the showButton. I also did some cleanup and refactoring of the eventListeners section by creating a processEventListenerElement() function. 

Once this was working, for a large chunk of the day today, I tried in vain to add a backward (<) and forward (>) button before and after the key selection element in order to make it so that I could raise or lower the key incrementally by just tapping the buttons. Unfortunately I was not able to get it to work (I was able to make the buttons move the scale by one fret in either direction, but no more than that). 

I also removed the updateDisplay() function because the data is now displaying directly to the screen (hope I didn't remove that too soon!).

I find that I'm still a bit confused on exactly how `this.col` in the `Fret()` constructor and the `color()` P5 method is working together as it is now. It feels redundant for color properties to be set in the `Fret` constructor as well as in the `activateFrets()` function. However, it doesn't work when I try to break this functionality apart.

Thanks, and ttys - hope you have a great weekend!
