### PR TITLE
question about fretShapes on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,7 +7,6 @@
   <meta name="description" content="Guitar Scale Visualizer">
   <meta name="keywords" content="guitar,scales,shapes,modes,fretboard">
   <meta name="author" content="Raleigh Green">
-  <!-- <meta name="viewport", content="width=device-width, user-scalable=no, minimal-ui" id="viewport-meta"> -->
   <meta name="viewport", content="minimal-ui">
   <meta name="google-site-verification" content="3gyJKIrIkTCJaRP3M9Qwa9eLIgIaE1FCyGNZywLBHO0" />
   <!-- Open Graph -->

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -845,28 +845,6 @@ function setup() {
 function draw() {
   background(0);
 
-  // if (screen.width <= 320) {
-  // //   document.getElementById('viewport-meta').setAttribute("content", "initial-scale=.32");
-  // //   document.getElementById('viewport-meta').setAttribute("content", "maximum-scale=.32");
-  //   document.getElementById('viewport-meta').setAttribute("content", "width=320");
-  // } else if (screen.width <= 568) {
-  // //   document.getElementById('viewport-meta').setAttribute("content", "initial-scale=.75");
-  // //   document.getElementById('viewport-meta').setAttribute("content", "maximum-scale=.75");
-  // document.getElementById('viewport-meta').setAttribute("content", "width=568");
-  // } else if (screen.width <= 768) {
-  // //   document.getElementById('viewport-meta').setAttribute("content", "initial-scale=.9");
-  // //   document.getElementById('viewport-meta').setAttribute("content", "maximum-scale=.9");
-  // document.getElementById('viewport-meta').setAttribute("content", "width=768");
-  // } else if (screen.width <= 1024) {
-  // //   document.getElementById('viewport-meta').setAttribute("content", "initial-scale=1.2");
-  // //   document.getElementById('viewport-meta').setAttribute("content", "maximum-scale=1.2");
-  // document.getElementById('viewport-meta').setAttribute("content", "width=1024");
-  // } else if (screen.width > 1025) {
-  // //   document.getElementById('viewport-meta').setAttribute("content", "initial-scale=1.7");
-  // //   document.getElementById('viewport-meta').setAttribute("content", "maximum-scale=1.7");
-  // document.getElementById('viewport-meta').setAttribute("content", "width=1025");
-  // }
-
   // If app screen is in view, display the guitar body background
   if(fretArt.guitarBodyDisplay) {
     buildGuitarBody();


### PR DESCRIPTION
Hi Kevin,

Hope all is well!

I'm stuck on a problem and was hoping to get your input.

The good news is: fretShapes works pretty well on mobile! 
The bad news is: It works, but there are issues once a double-tap is detected. The screen zooms in - and then (since it seems pinch-zoom only works outside of the P5 canvas area) its very hard to pinch back out and recover the correct layout. Usually the only thing that works is refreshing the page. 

I've tried a number of approaches to get it to work on mobile, including messing with the viewport meta tag in the HTML directly and also trying to set device-width breakpoints with javascript. Frustratingly, I actually got this to work really well in the Chrome Dev tools mobile emulator, but the results ended up being totally different (and quite messed up) once published and tested on actual devices. Feeling pretty defeated with it at this point.

So, in this pull request I reverted back to where I was before in the hopes of getting your input on how best to address these issues.

Ideally, I just want mobile users to be able to drag their finger across the screen or tap (including fast taps that might register as double-taps) in order to play on the fretboard without resizing, zooming or scrolling the screen. 

Any ideas on how to achieve this?

All in all, it seems like I have these options:

1. On mobile devices, display a screen that says that "fretShapes is not intended to be used on mobile" and to please check it out on a laptop or desktop. I should say that even though it looks pretty good on mobile, I would not say that it feels like an optimized mobile web app. I suppose there is an argument for only making it available on desktop in order to restrict it to the platform that it was designed for.
- Do you think this is a viable option to display a message?
- If so, what's the best way to detect whether or not it's a mobile device so that I can trigger the message to be displayed?

2. Leave fretShapes on the web in it's current state - where it looks really good on all devices but once a user starts double-tapping it gets really messed up due to double-tap zoom issues. 
- This means that the user will need to refresh their browser in order to get back to normal. Not at all ideal, but it is an option.

3. Try to fix the issue(s) and make it presentable and working on mobile. I would need help with this as I've tried everything I can think of. 
- Do you think it would be possible to get it working on mobile, and would it be worth it?

Do you have any thoughts on what my options might be with this, and what you would suggest as a best course of action? 

Thanks so much Kevin!


